### PR TITLE
Trace the execution of 1 run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,10 @@ services:
     volumes: 
       - ./server/:/usr/src/app/
   zipkin:
-      image: ghcr.io/openzipkin/zipkin-slim:${TAG:-latest}
-      container_name: zipkin
-      # Environment settings are defined here https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md#environment-variables
-      environment:
-        - STORAGE_TYPE=mem
-      ports:
-        - 9411:9411
+    image: ghcr.io/openzipkin/zipkin-slim:${TAG:-latest}
+    container_name: zipkin
+    # Environment settings are defined here https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md#environment-variables
+    environment:
+      - STORAGE_TYPE=mem
+    ports:
+      - 9411:9411

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,11 @@ services:
     volumes: 
       - ./server/:/usr/src/app/
     command: ["python", "app.py"]
+  zipkin:
+      image: ghcr.io/openzipkin/zipkin-slim:${TAG:-latest}
+      container_name: zipkin
+      # Environment settings are defined here https://github.com/openzipkin/zipkin/blob/master/zipkin-server/README.md#environment-variables
+      environment:
+        - STORAGE_TYPE=mem
+      ports:
+        - 9411:9411

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     build: ./server/
     volumes: 
       - ./server/:/usr/src/app/
-    command: ["python", "app.py"]
   zipkin:
       image: ghcr.io/openzipkin/zipkin-slim:${TAG:-latest}
       container_name: zipkin

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -13,5 +13,7 @@ COPY . .
 
 #Run the command
 ENV OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+ENV OTEL_METRICS_EXPORTER=none
+ENV OTEL_LOGS_EXPORTER=none
 
-CMD ["opentelemetry-instrument", "--metrics_exporter", "console", "--traces_exporter", "console", "--logs_exporter", "console", "python3.9", "./app.py"]
+CMD ["opentelemetry-instrument", "--traces_exporter", "zipkin_json", "python3.9", "./app.py"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,16 +1,17 @@
 FROM python:3.9
 
+COPY requirements.txt /opt/app/requirements.txt
+WORKDIR /opt/app
+RUN pip install -r requirements.txt
+RUN opentelemetry-bootstrap --action=install
+
 #Set the working directory
 WORKDIR /usr/src/app
 
 #copy all the files
 COPY . .
 
-#Install the dependencies
-RUN pip install -r requirements.txt
-RUN opentelemetry-bootstrap --action=install
-
-# # #Run the command
+#Run the command
 ENV OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 
 CMD ["opentelemetry-instrument", "--metrics_exporter", "console", "--traces_exporter", "console", "--logs_exporter", "console", "python3.9", "./app.py"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -11,4 +11,6 @@ RUN pip install -r requirements.txt
 RUN opentelemetry-bootstrap --action=install
 
 # # #Run the command
-CMD ["python ./app.py"]
+ENV OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
+
+CMD ["opentelemetry-instrument", "--metrics_exporter", "console", "--traces_exporter", "console", "--logs_exporter", "console", "python3.9", "./app.py"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,6 +8,7 @@ COPY . .
 
 #Install the dependencies
 RUN pip install -r requirements.txt
+RUN opentelemetry-bootstrap --action=install
 
 # # #Run the command
 CMD ["python ./app.py"]

--- a/server/app.py
+++ b/server/app.py
@@ -55,6 +55,6 @@ def get_cards():
 
 
 if __name__ == "__main__":
-    with tracer.start_as_current_span("service_life") as parent:
+    with tracer.start_as_current_span("service_start") as parent:
         parent.set_attribute("LOOK_AT_ME", 696969)
-        app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/server/app.py
+++ b/server/app.py
@@ -33,10 +33,13 @@ def get_cards():
         cards = []
         api_key = request.form.get('api_key')  
         response = get_card_page(api_key=api_key)
+        # TODO publish a span for how long it took to retrieve cards and how many were retrieved
         cards += response['docs']
         while len(response['docs']) > 0 and len(cards) < 500:
             response = get_card_page(api_key, response['bookmark'])
             cards += response['docs']
+
+        # TODO publish a span for how long it took to make all the links
         links = make_links(cards)
         result = {'error': False, 'cards': cards, 'links': links}
     except KeyError:

--- a/server/app.py
+++ b/server/app.py
@@ -35,17 +35,24 @@ def get_card_page(api_key, bookmark=None):
     return requests.get("https://app.mochi.cards/api/cards", params={"bookmark":bookmark}, auth=(api_key, None)).json()
 
 
-@app.route("/api/cards", methods=['POST'])
-def get_cards():
-    try:
-        cards = []
-        api_key = request.form.get('api_key')  
+def get_all_cards(api_key):
+    cards = []
+    with tracer.start_as_current_span("card_getter") as getter_span:
         response = get_card_page(api_key=api_key)
-        # TODO publish a span for how long it took to retrieve cards and how many were retrieved
+        # TODO publish a span for how long it took to retrieve cards
         cards += response['docs']
         while len(response['docs']) > 0 and len(cards) < 500:
             response = get_card_page(api_key, response['bookmark'])
             cards += response['docs']
+        getter_span.set_attribute("cards_retrieved", len(cards))
+    return cards
+
+
+@app.route("/api/cards", methods=['POST'])
+def get_cards():
+    try:
+        api_key = request.form.get('api_key')
+        cards = get_all_cards(api_key)
 
         # TODO publish a span for how long it took to make all the links
         links = make_links(cards)
@@ -58,4 +65,5 @@ def get_cards():
 if __name__ == "__main__":
     with tracer.start_as_current_span("service_start") as parent:
         parent.set_attribute("LOOK_AT_ME", 696969)
+        parent.add_event("Starting the server")
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/server/app.py
+++ b/server/app.py
@@ -15,7 +15,8 @@ resource = Resource(attributes={
     SERVICE_NAME: "MOCHI_POWERED_BY_LLMs"
 })
 
-zipkin_exporter = ZipkinExporter(endpoint="http://localhost:9411/api/v2/spans")
+zipkin_exporter = ZipkinExporter(endpoint="http://zipkin:9411/api/v2/spans")
+
 
 provider = TracerProvider(resource=resource)
 processor = BatchSpanProcessor(zipkin_exporter)

--- a/server/app.py
+++ b/server/app.py
@@ -5,16 +5,23 @@ from cluster import make_links
 from flask import Flask, request
 import requests
 
-from opentelemetry import metrics
+from opentelemetry import trace
+from opentelemetry.exporter.zipkin.proto.http import ZipkinExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 
-# Acquire a meter.
-meter = metrics.get_meter("diceroller.meter")
+resource = Resource(attributes={
+    SERVICE_NAME: "MOCHI_POWERED_BY_LLMs"
+})
 
-# Now create a counter instrument to make measurements with
-roll_counter = meter.create_counter(
-    "dice.rolls",
-    description="The number of rolls by roll value",
-)
+zipkin_exporter = ZipkinExporter(endpoint="http://localhost:9411/api/v2/spans")
+
+provider = TracerProvider(resource=resource)
+processor = BatchSpanProcessor(zipkin_exporter)
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer("TRACER_TEST")
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -48,5 +55,6 @@ def get_cards():
 
 
 if __name__ == "__main__":
-    roll_counter.add(1, {"roll.value": "3"})
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    with tracer.start_as_current_span("service_life") as parent:
+        parent.set_attribute("LOOK_AT_ME", 696969)
+        app.run(host='0.0.0.0', port=5000, debug=True)

--- a/server/app.py
+++ b/server/app.py
@@ -5,6 +5,17 @@ from cluster import make_links
 from flask import Flask, request
 import requests
 
+from opentelemetry import metrics
+
+# Acquire a meter.
+meter = metrics.get_meter("diceroller.meter")
+
+# Now create a counter instrument to make measurements with
+roll_counter = meter.create_counter(
+    "dice.rolls",
+    description="The number of rolls by roll value",
+)
+
 # Setup logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('mochi')
@@ -34,4 +45,5 @@ def get_cards():
 
 
 if __name__ == "__main__":
+    roll_counter.add(1, {"roll.value": "3"})
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,3 +2,5 @@ flask
 requests
 ollama
 scikit-learn
+opentelemetry-distro
+opentelemetry-instrumentation

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,3 +4,4 @@ ollama
 scikit-learn
 opentelemetry-distro
 opentelemetry-instrumentation
+opentelemetry-exporter-zipkin-proto-http


### PR DESCRIPTION
Use opentelemetry to trace through the execution - will enable us to track
how many cards were retrieved and how many of those did/didn't have
embeddings generated for

didn't have a particular reason to use zipkin, got it to work easily enough though