### PR TITLE
Use a new python and a smaller image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.13-slim
 
 COPY requirements.txt /opt/app/requirements.txt
 WORKDIR /opt/app
@@ -16,4 +16,4 @@ ENV OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED=true
 ENV OTEL_METRICS_EXPORTER=none
 ENV OTEL_LOGS_EXPORTER=none
 
-CMD ["opentelemetry-instrument", "--traces_exporter", "zipkin_json", "python3.9", "./app.py"]
+CMD ["opentelemetry-instrument", "--traces_exporter", "zipkin_json", "python3.13", "./app.py"]


### PR DESCRIPTION
Use the most recent, stable version of python in a slim docker image